### PR TITLE
Auth Params tab

### DIFF
--- a/src/public/react/components/AuthParamsMap.react.jsx
+++ b/src/public/react/components/AuthParamsMap.react.jsx
@@ -1,0 +1,77 @@
+var React  = require('react');
+
+var FormTextGroup     = require('./FormTextGroup.react');
+
+var AuthParamsMap = React.createClass({
+  propTypes: {
+    mode:         React.PropTypes.string,
+    defaultValue: React.PropTypes.object
+  },
+  getInitialState: function () {
+    return {
+      successMessage:   {display: 'none'},
+      mode:             this.props.mode,
+      defaultValue:     this.props.defaultValue || {}
+    };
+  },
+
+  showSuccessMessage: function () {
+    this.setState({
+      successMessage: {}
+    });
+  },
+
+  getParamMappings: function () {
+    var body = {};
+
+    Object.keys(this.refs).map(function (key) {
+      var value = this.refs[key].getValue();
+      if (value) {
+        body[value] = key;
+      }
+    }.bind(this));
+
+    return body;
+  },
+
+  render: function () {
+    const fields = ['force_login', 'login_hint', 'whr', 'wauth', 'hd', 'access_type', 'prompt', 'approval_prompt', 'display', 'include_granted_scopes', 'resource'];
+
+    var fieldValues = {};
+    Object.keys(this.state.defaultValue).forEach(function (mapping) {
+      fieldValues[this.state.defaultValue[mapping]] = mapping;
+    }.bind(this));
+
+    var fieldMappings = fields.map(function (field) {
+      return (
+        <div className="col-xs-6" key={field}>
+          <FormTextGroup
+            title={field}
+            defaultValue={fieldValues[field]}
+            required={false}
+            ref={field}/>
+        </div>
+      );
+    });
+
+    return (
+      <div className="modal-body" style={{paddingTop: '0', paddingBottom: '15px'}}>
+        <div className="connection-name form-group">
+          <div className="info-area" style={this.state.successMessage}>
+            <div className="alert alert-success" role="alert" style={{marginBottom: '0'}}>
+              Auth Param settings saved successfully
+            </div>
+          </div>
+        </div>
+
+        <div className="form-group">
+          <div className="row">
+            {fieldMappings}
+          </div>
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = AuthParamsMap;

--- a/src/public/react/components/ConnectionModal.react.jsx
+++ b/src/public/react/components/ConnectionModal.react.jsx
@@ -3,6 +3,7 @@ var Switch     = require('./Switch.react');
 var classNames = require('classnames');
 
 var ConnectionForm = require('./ConnectionForm.react');
+var AuthParamsMap = require('./AuthParamsMap.react');
 var Applications   = require('./Applications.react');
 var Try            = require('./Try.react');
 
@@ -17,6 +18,7 @@ var ConnectionModal = React.createClass({
   getInitialState: function () {
     return {
       showSettings:   true,
+      showAuthParamsMap: false,
       showApps:       false,
       showTry:        this.props.mode === '_update' ? (window.env.userUrl ? true : false) : false,
       connection:     this.props.connection || {strategy:'oauth2', options: {scripts: {
@@ -48,6 +50,7 @@ var ConnectionModal = React.createClass({
 
     this.setState({
       connectionForm:   React.render(<ConnectionForm onShare={this._share} defaultValue={this.state.connection} mode={this.state.mode}/>, document.getElementById('connectionForm')),
+      authParamsMapForm:   React.render(<AuthParamsMap defaultValue={this.state.connection.options.authParamsMap} mode={this.state.mode}/>, document.getElementById('authParamsMapForm')),
       applicationsForm: React.render(<Applications mode={this.state.mode} defaultValue={this.state.connection.enabled_clients}/>, document.getElementById('applicationsForm')),
     });
   },
@@ -62,8 +65,9 @@ var ConnectionModal = React.createClass({
 
   _showMe: function (active) {
     var tabs = {
-      showSettings: false,
-      showApps:     false
+      showSettings:   false,
+      showAuthParamsMap: false,
+      showApps:       false
     };
 
     tabs[active] = true;
@@ -79,6 +83,11 @@ var ConnectionModal = React.createClass({
   _saveConnection: function (e) {
     e.preventDefault();
     this._save(this.state.connectionForm);
+  },
+
+  _saveAuthParamsMap: function (e) {
+    e.preventDefault();
+    this._save(this.state.authParamsMapForm);
   },
 
   _generateTryItUrl: function () {
@@ -112,7 +121,8 @@ var ConnectionModal = React.createClass({
             </div>
             <div className="form-wrapper">
               <ul className="nav nav-tabs">
-                <li className={classNames({'active': this.state.showSettings})}><a href="#" onClick={this._showMe.bind(this, 'showSettings')}>Settings</a></li>
+                <li className={classNames({ 'active': this.state.showSettings })}><a href="#" onClick={this._showMe.bind(this, 'showSettings')}>Settings</a></li>
+                <li className={classNames({ 'active': this.state.showAuthParamsMap })}><a href="#" onClick={this._showMe.bind(this, 'showAuthParamsMap')}>Auth Params Map</a></li>
                 <li className={classNames({'active': this.state.showApps})}><a href="#"     onClick={this._showMe.bind(this, 'showApps')}>Apps</a></li>
               </ul>
             </div>
@@ -159,6 +169,18 @@ var ConnectionModal = React.createClass({
                       })}>
                         <span className="text">View PR</span>
                       </a>
+                    </div>
+                  </form>
+                </div>
+
+                <div id="auth-params" className={classNames({ 'tab-pane': true, 'active': this.state.showAuthParamsMap })}>
+                  <form className="connection-form form" onSubmit={this._saveAuthParamsMap}>
+                    <div id="authParamsMapForm"></div>
+                    <div className="modal-footer text-center">
+                      <button disabled={this.state.saving} type="submit" className="btn btn-primary save">
+                        <span className={classNames({ 'hide': this.state.saving })}>Save</span>
+                        <span className={classNames({ 'hide': !this.state.saving })}>Saving ...</span>
+                      </button>
                     </div>
                   </form>
                 </div>

--- a/src/public/react/mixins/OperationsMixin.jsx
+++ b/src/public/react/mixins/OperationsMixin.jsx
@@ -116,12 +116,15 @@ var OperationsMixin = {
   _save: function (context) {
     var clients = this.state.applicationsForm.getSelectedClients();
     var connection = this.state.connectionForm.getConnection();
+    var paramsMap = this.state.authParamsMapForm.getParamMappings();
+
     var param = this.state.mode === '_create' ? connection.isShared : connection.id;
     var isTemplate = connection.isTemplate;
     var currentOptions = this.state.connection && this.state.connection.options || {};
 
     connection.options = Object.assign({}, currentOptions, connection.options);
     connection.enabled_clients = Object.keys(clients);
+    connection.options.authParamsMap = paramsMap;
     delete connection.id;
     delete connection.isShared;
     delete connection.isTemplate;


### PR DESCRIPTION
## ✏️ Changes

Added Auth Params Map tab to configure whitelisted fields mapping, according to issue #14. Existing code was adapted just to accomodate the new tab in the UI, and map the tab's state to the `options.authParamsMap` property.
  
## 📷 Screenshots
 
![image](https://user-images.githubusercontent.com/1435258/55993291-61bc1f00-5cb7-11e9-8426-5306ab9e4395.png)

  
## 🔗 References
  
UI implementation for [dynamic connection parameters](https://auth0.com/docs/connections/pass-parameters-to-idps#dynamic-parameters).
  
## 🎯 Testing

1. Create custom connection
2. Set any of the fields of _Auth Params Map_ tab to a custom value (e.g. set _access_type_ to _myqueryparam_)
3. Set devtools to persists all network activity
4. Copy URL from TRY button in _Settings_ tab, add your custom field with a value to the querystring, and navigate to the modified URL (e.g. _&access_type=myvalue_)
5. On the authorize endpoint call, the custom field should be in the URL with the value edited onto the URL on previous step (e.g. _myqueryparam=myvalue_)
   
✅ This change has been tested in a Webtask (locally)
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
No dependencies
  
✅ This can be deployed any time
 
## 🎡 Rollout
  
In order to verify that the deployment was successful we will test the mapping using the steps from the Testing section.
  
## 🔥 Rollback
  
We will rollback if rollout manual test fails.
  
### 📄 Procedure
  
Extension is stateless, so reverting the deployment should be enough. Affected data is managed by Auth0 Management API, and is not affected by this change.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
