### PR TITLE
PR for ES-1843

### DIFF
--- a/src/public/react/components/ConnectionModal.react.jsx
+++ b/src/public/react/components/ConnectionModal.react.jsx
@@ -85,7 +85,7 @@ var ConnectionModal = React.createClass({
     return [
       window.env.userUrl + '?',
       'response_type=code',
-      '&scope=openid%20profile',
+      '&scope=' + encodeURIComponent(this.state.connection.options.scope),
       '&client_id=' + window.env.masterClientId,
       '&connection=' + this.state.connection.name,
       '&redirect_uri=' + window.env.manageUrl + '/tester/callback?connection=' + this.state.connection.name


### PR DESCRIPTION
## ✏️ Changes
  
The "Try" button of a custom social connection ignored the scope configuration entirely, because it was hardcoded. This should fix it, but please review, I wasn't able to deploy/test this extension anywhere. This PR is based on looking at the code.
  
## 📷 Screenshots
 
See https://auth0team.atlassian.net/servicedesk/customer/portal/34/ESD-1843
  
## 🔗 References
  
See https://auth0team.atlassian.net/servicedesk/customer/portal/34/ESD-1843
  
## 🎯 Testing
  
See https://auth0team.atlassian.net/servicedesk/customer/portal/34/ESD-1843

Configure a custom social connection and change the default scope configuration. The scopes should not be ignored when running the "Try" command. 
Before, it was hardcoded as 'openid profile' and ignoring any additional scopes set in the configuration.
   
✅🚫 This change has been tested in a Webtask
 
✅🚫 This change has unit test coverage
  
✅🚫 This change has integration test coverage
  
✅🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅🚫 This can be deployed any time
  
> or
> ⚠️ This should not be merged until:
> - Other PR is merged because REASON
> - After date because REASON
> - Other condition: REASON
  
## 🎡 Rollout
  
> Explain how the change will be verified once released. Manual testing? Functional testing?
  
In order to verify that the deployment was successful we will …
  
## 🔥 Rollback
  
> Explain when and why we will rollback the change.
  
We will rollback if …
  
### 📄 Procedure
  
> Explain how the rollback for this change will look like, how we can recover fast.
 
## 🖥 Appliance
  
Please review carefully, I wasn't able to deploy/test this extension anywhere. This PR is based on looking at the code.
