### PR TITLE
[SEC-2451] Upgrade codemirror to 5.58.2 to fix snyk vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "auth0-oauth2-express": "1.1.10",
         "classnames": "~2.1.3",
-        "codemirror": "^5.8.0",
+        "codemirror": "^5.58.2",
         "express": "4.14.0",
         "flux": "~2.0.1",
         "js-beautify": "^1.5.10",
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.55.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/codemirror/-/codemirror-5.55.0.tgz",
-      "integrity": "sha1-I3MfZBKI8gKmhY/ch48xSeDgQ2M="
+      "version": "5.65.18",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/codemirror/-/codemirror-5.65.18.tgz",
+      "integrity": "sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA=="
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
@@ -6037,9 +6037,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.55.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/codemirror/-/codemirror-5.55.0.tgz",
-      "integrity": "sha1-I3MfZBKI8gKmhY/ch48xSeDgQ2M="
+      "version": "5.65.18",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/codemirror/-/codemirror-5.65.18.tgz",
+      "integrity": "sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA=="
     },
     "collection-visit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "auth0-oauth2-express": "1.1.10",
     "classnames": "~2.1.3",
-    "codemirror": "^5.8.0",
+    "codemirror": "^5.58.2",
     "express": "4.14.0",
     "flux": "~2.0.1",
     "js-beautify": "^1.5.10",


### PR DESCRIPTION
## ✏️ Changes
  
Upgrade codemirror due to high severity snyk vulnerability found in the current version.

  
## 🔗 References
  
https://auth0team.atlassian.net/browse/SEC-2451
https://auth0team.atlassian.net/browse/ULP-6499

## 🎯 Testing
   
✅🚫 This change has been tested in a Webtask
 
✅🚫 This change has unit test coverage
  
✅🚫 This change has integration test coverage
  
✅🚫 This change has been tested for performance
  
## 🚀 Deployment

  
✅ This can be deployed any time
  

  
## 🎡 Rollout

  
In order to verify that the deployment was successful we will …
  
## 🔥 Rollback
  
  
We will rollback if there are any breaking changes
  
### 📄 Procedure
  
Revert this PR
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
